### PR TITLE
Adding id property to the second options hash to `warn`

### DIFF
--- a/app/services/rdfa-editor-dispatcher.js
+++ b/app/services/rdfa-editor-dispatcher.js
@@ -54,11 +54,11 @@ let service = {
           else if (typeof(pluginService.get('execute')) == 'function') {
             pluginService.execute(hintsRegistryIndex, contexts, hintsRegistry, editor, extraInfo);
           } else {
-            warn(`Plugin ${plugin} doesn't provide 'execute' as function nor ember-concurrency task`);
+            warn(`Plugin ${plugin} doesn't provide 'execute' as function nor ember-concurrency task`, { id: "disptacher_plugin_no_execute" });
           }
         });
       } else {
-        warn(`Editor plugin profile "${profile}" was not found`);
+        warn(`Editor plugin profile "${profile}" was not found`, { id: "disptacher_no_profile" });
       }
       resolve();
 


### PR DESCRIPTION
The id property in the options hash should be a string.  Not sure what
the desired format is but this is a step in the right direction.

Can be merged as is, or we could figure out a good way for the id.

----

#